### PR TITLE
Fixed a bug that occurs when the path contains a period

### DIFF
--- a/lib/es6-migrate.js
+++ b/lib/es6-migrate.js
@@ -170,7 +170,7 @@ class ES6Migrate {
    */
   migrateFiles () {
     console.log('Migrating...')
-    const origExt = this._files[0].substr(this._files[0].search(/\./))
+    const origExt = this._files[0].substr(this._files[0].search(/\.[^.]+$/))
     const newExt = this._newExt
 
     const lastFile = (i) => i === this._files.length - 1


### PR DESCRIPTION
I found that if the path contains a `.` all files are written with the extension `.coffee.js`.